### PR TITLE
Deprecated DfE.CoreLibs packages

### DIFF
--- a/.github/actions/validate-packages/packages-policy.json
+++ b/.github/actions/validate-packages/packages-policy.json
@@ -11,72 +11,102 @@
       ]
     },
     {
-      "name": "DfE.CoreLibs.Testing",
+      "nameRegex": "^(?i)DfE\\.CoreLibs\\..*$",
       "rules": [
         {
-          "versionRegex": "-prerelease",
-          "environments": [ "production" ],
-          "message": "PreRelease versions of DfE.CoreLibs.Testing are not allowed in production."
+          "environments": [ "production", "development", "test" ],
+          "versionRegex": ".*",
+          "message": "DfE.CoreLibs.* packages are deprecated, please use GovUK.Dfe.CoreLibs.* packages on nuget.org."
         }
       ]
     },
     {
-      "name": "DfE.CoreLibs.Utilities",
+      "name": "GovUK.Dfe.CoreLibs.Testing",
       "rules": [
         {
           "versionRegex": "-prerelease",
           "environments": [ "production" ],
-          "message": "PreRelease versions of DfE.CoreLibs.Utilities are not allowed in production."
+          "message": "PreRelease versions of GovUK.Dfe.CoreLibs.Testing are not allowed in production."
         }
       ]
     },
     {
-      "name": "DfE.CoreLibs.Caching",
+      "name": "GovUK.Dfe.CoreLibs.Utilities",
       "rules": [
         {
           "versionRegex": "-prerelease",
           "environments": [ "production" ],
-          "message": "PreRelease versions of DfE.CoreLibs.Caching are not allowed in production."
+          "message": "PreRelease versions of GovUK.Dfe.CoreLibs.Utilities are not allowed in production."
         }
       ]
     },
     {
-      "name": "DfE.CoreLibs.Http",
+      "name": "GovUK.Dfe.CoreLibs.Caching",
       "rules": [
         {
           "versionRegex": "-prerelease",
           "environments": [ "production" ],
-          "message": "PreRelease versions of DfE.CoreLibs.Http are not allowed in production."
+          "message": "PreRelease versions of GovUK.Dfe.CoreLibs.Caching are not allowed in production."
         }
       ]
     },
     {
-      "name": "DfE.CoreLibs.Contracts",
+      "name": "GovUK.Dfe.CoreLibs.Http",
       "rules": [
         {
           "versionRegex": "-prerelease",
           "environments": [ "production" ],
-          "message": "PreRelease versions of DfE.CoreLibs.Contracts are not allowed in production."
+          "message": "PreRelease versions of GovUK.Dfe.CoreLibs.Http are not allowed in production."
         }
       ]
     },
     {
-      "name": "DfE.CoreLibs.Security",
+      "name": "GovUK.Dfe.CoreLibs.Contracts",
       "rules": [
         {
           "versionRegex": "-prerelease",
           "environments": [ "production" ],
-          "message": "PreRelease versions of DfE.CoreLibs.Security are not allowed in production."
+          "message": "PreRelease versions of GovUK.Dfe.CoreLibs.Contracts are not allowed in production."
         }
       ]
     },
     {
-      "name": "DfE.CoreLibs.AsyncProcessing",
+      "name": "GovUK.Dfe.CoreLibs.Security",
       "rules": [
         {
           "versionRegex": "-prerelease",
           "environments": [ "production" ],
-          "message": "PreRelease versions of DfE.CoreLibs.AsyncProcessing are not allowed in production."
+          "message": "PreRelease versions of GovUK.Dfe.CoreLibs.Security are not allowed in production."
+        }
+      ]
+    },
+    {
+      "name": "GovUK.Dfe.CoreLibs.AsyncProcessing",
+      "rules": [
+        {
+          "versionRegex": "-prerelease",
+          "environments": [ "production" ],
+          "message": "PreRelease versions of GovUK.Dfe.CoreLibs.AsyncProcessing are not allowed in production."
+        }
+      ]
+    },
+    {
+      "name": "GovUK.Dfe.CoreLibs.Notifications",
+      "rules": [
+        {
+          "versionRegex": "-prerelease",
+          "environments": [ "production" ],
+          "message": "PreRelease versions of GovUK.Dfe.CoreLibs.Notifications are not allowed in production."
+        }
+      ]
+    },
+    {
+      "name": "GovUK.Dfe.CoreLibs.FileStorage",
+      "rules": [
+        {
+          "versionRegex": "-prerelease",
+          "environments": [ "production" ],
+          "message": "PreRelease versions of GovUK.Dfe.CoreLibs.FileStorage are not allowed in production."
         }
       ]
     }

--- a/.github/actions/validate-packages/validate-packages.ps1
+++ b/.github/actions/validate-packages/validate-packages.ps1
@@ -17,69 +17,128 @@ $csprojFiles = Get-ChildItem -Path . -Filter *.csproj -Recurse
 
 $errors = @()
 
+function TryParse-Version([string] $v, [ref] [Version] $out) {
+    # Accept only pure numeric versions for [Version]; ignore things like -beta.
+    # Extract the first N.N or N.N.N run for safe parsing.
+    if ([string]::IsNullOrWhiteSpace($v)) { return $false }
+    $null = $v -match '(\d+(?:\.\d+){1,2})'  # 1.2 or 1.2.3
+    if ($Matches -and $Matches[1]) {
+        try {
+            $out.Value = [Version]$Matches[1]
+            return $true
+        } catch {
+            return $false
+        }
+    }
+    return $false
+}
+
 ForEach ($file in $csprojFiles) {
     Write-Host "Scanning $($file.FullName)..."
 
     # Load XML from the .csproj
     [xml]$xmlContent = Get-Content $file.FullName
 
-    # Select all PackageReference
-    $packageRefs = $xmlContent.Project.ItemGroup.PackageReference
+    # Select all PackageReference (guard for multiple ItemGroups)
+    $packageRefs = @()
+    $xmlContent.Project.ItemGroup | ForEach-Object {
+        if ($_.PackageReference) { $packageRefs += $_.PackageReference }
+    }
 
     ForEach ($ref in $packageRefs) {
-        $packageName = $ref.Include
-        $packageVersion = $ref.Version
+        $packageName    = [string]$ref.Include
+        # Do NOT skip when Version is missing; rules like versionRegex: ".*" should still apply.
+        $packageVersion = [string]$ref.Version  # becomes "" when missing
 
-        if (-not $packageVersion) {
-            # TODO: Some csproj might define versions in Directory.Packages.props, implement a solution for centralized packages
-            Continue
+        if ([string]::IsNullOrWhiteSpace($packageName)) {
+            continue
         }
 
-        # Now check against each rule
+        # Evaluate against each policy block
         ForEach ($packagePolicy in $disallowedPackages) {
 
-            if ($packagePolicy.name -eq $packageName) {
+            # Name matching: prefer nameRegex (case-insensitive), otherwise exact name (case-insensitive)
+            $matchesName = $false
+            $hasNameRegex = $packagePolicy.PSObject.Properties.Name -contains 'nameRegex'
+            $hasNameExact = $packagePolicy.PSObject.Properties.Name -contains 'name'
 
-                # This package has rules we need to check
-                ForEach ($rule in $packagePolicy.rules) {
+            if ($hasNameRegex) {
+                $namePattern = [string]$packagePolicy.nameRegex
+                if (-not [string]::IsNullOrWhiteSpace($namePattern)) {
+                    # -imatch is case-insensitive
+                    $matchesName = ($packageName -imatch $namePattern)
+                }
+            } elseif ($hasNameExact) {
+                $matchesName = ($packagePolicy.name -ieq $packageName)
+            } else {
+                # If neither name nor nameRegex is present, skip this policy
+                continue
+            }
 
-                    # Does this rule apply to our envionment?
-                    if ($rule.environments -contains $Environment) {
+            if (-not $matchesName) {
+                continue
+            }
 
-                        # Check versionConstraint
-                        if ($rule.PSObject.Properties.Name -contains 'versionConstraint') {
-                            $constraint = $rule.versionConstraint
+            # This package matches the policy "target"; check rules
+            ForEach ($rule in $packagePolicy.rules) {
+                if (-not ($rule.environments -contains $Environment)) {
+                    continue
+                }
 
-                            $minVersionMatch = $constraint -match "(\d+\.?\d*\.?\d*)"
+                $msg = [string]$rule.message
+                if ([string]::IsNullOrWhiteSpace($msg)) {
+                    $msg = "Package violates policy."
+                }
 
-                            if ($constraint.StartsWith("<")) {
-                                $ruleVersion = $Matches[1]
+                $hasVersionConstraint = $rule.PSObject.Properties.Name -contains 'versionConstraint'
+                $hasVersionRegex      = $rule.PSObject.Properties.Name -contains 'versionRegex'
+                $hasDisallowAll       = $rule.PSObject.Properties.Name -contains 'disallowAllVersions'
+                $disallowAll          = $hasDisallowAll -and [bool]$rule.disallowAllVersions
 
-                                $parsedRuleVersion = [Version]$ruleVersion
-                                $parsedPackageVersion = [Version]$packageVersion
-                                
-                                if ($parsedPackageVersion -lt $parsedRuleVersion) {
-                                    $errors += "$($file.FullName): Package $($packageName) version $($packageVersion) violates rule: $($rule.message)"
+                # Blanket disallow (if we ever choose to use it in policy)
+                if ($disallowAll) {
+                    $errors += "$($file.FullName): Package $packageName version '$packageVersion' violates rule: $msg"
+                    continue
+                }
+
+                # Version constraint (e.g., "<7.0.0" or ">7.0.0")
+                if ($hasVersionConstraint) {
+                    $constraint = [string]$rule.versionConstraint
+                    if (-not [string]::IsNullOrWhiteSpace($constraint)) {
+
+                        # Parse the numeric portion of the rule version
+                        $ruleVer = $null
+                        $okRule = TryParse-Version $constraint ([ref]$ruleVer)
+
+                        # Parse the package version
+                        $pkgVer = $null
+                        $okPkg = TryParse-Version $packageVersion ([ref]$pkgVer)
+
+                        if ($okRule -and $okPkg) {
+                            if ($constraint.StartsWith('<')) {
+                                # Disallow any package version that is LESS than the rule version
+                                if ($pkgVer -lt $ruleVer) {
+                                    $errors += "$($file.FullName): Package $packageName version '$packageVersion' violates rule: $msg"
                                 }
-                            } elseif ($constraint.StartsWith(">")) {
-                                $ruleVersion = $Matches[1]
-
-                                $parsedRuleVersion = [Version]$ruleVersion
-                                $parsedPackageVersion = [Version]$packageVersion
-                                
-                                if ($parsedPackageVersion -gt $parsedRuleVersion) {
-                                    $errors += "$($file.FullName): Package $($packageName) version $($packageVersion) violates rule: $($rule.message)"
+                            } elseif ($constraint.StartsWith('>')) {
+                                # Disallow any package version that is GREATER than the rule version
+                                if ($pkgVer -gt $ruleVer) {
+                                    $errors += "$($file.FullName): Package $packageName version '$packageVersion' violates rule: $msg"
                                 }
                             }
-
+                        } else {
+                            # If we couldn't parse versions, we can't safely evaluate a numeric constraint.
+                            # For now, we skip.
                         }
-                        
-                        # Check versionRegex, 
-                        if ($rule.PSObject.Properties.Name -contains 'versionRegex') {
-                            $regex = $rule.versionRegex
-                            if ($packageVersion -match $regex) {
-                                $errors += "$($file.FullName): Package $($packageName) version $($packageVersion) violates rule: $($rule.message)"
-                            }
+                    }
+                }
+
+                # Version regex (works even if version is empty; ".*" will match empty)
+                if ($hasVersionRegex) {
+                    $regex = [string]$rule.versionRegex
+                    if (-not [string]::IsNullOrWhiteSpace($regex)) {
+                        if ($packageVersion -match $regex) {
+                            $errors += "$($file.FullName): Package $packageName version '$packageVersion' violates rule: $msg"
                         }
                     }
                 }
@@ -87,7 +146,6 @@ ForEach ($file in $csprojFiles) {
         }
     }
 }
-
 
 # Fail if we found any violations
 if ($errors.Count -gt 0) {


### PR DESCRIPTION
- Improved package validator PowerShell script
- Deprecated the old DfE.CoreLibs.* library packages for all the environments.
- Added new checks for the new GovUK.Dfe.CoreLibs.* prefixed packages