### PR TITLE
Version pinning updates

### DIFF
--- a/.github/actions/validate-packages/packages-policy.json
+++ b/.github/actions/validate-packages/packages-policy.json
@@ -1,12 +1,42 @@
 {
   "disallowedPackages": [
     {
+      "name": "MassTransit",
+      "rules": [
+        {
+          "versionConstraint": ">8.5.10",
+          "environments": [ "development", "test", "production" ],
+          "message": "MassTransit must be v8.5.10 or less."
+        }
+      ]
+    },
+    {
+      "name": "AutoMapper",
+      "rules": [
+        {
+          "versionConstraint": ">14.0.0",
+          "environments": [ "development", "test", "production" ],
+          "message": "AutoMapper must be v14.0.0 or less."
+        }
+      ]
+    },
+    {
       "name": "FluentAssertions",
       "rules": [
         {
-          "versionConstraint": ">7.0.0",
+          "versionConstraint": ">7.2.2",
           "environments": [ "development", "test", "production" ],
-          "message": "FluentAssertions must be v7.0.0 or less."
+          "message": "FluentAssertions must be v7.2.2 or less."
+        }
+      ]
+    },
+    {
+      "name": "MediatR",
+      "rules": [
+        {
+          "versionConstraint": ">12.5.0",
+          "environments": [ "development", "test", "production" ],
+          "message": "MediatR must be v12.5.0 or less."
         }
       ]
     },


### PR DESCRIPTION
#### PR Classification
Enforces stricter package version constraints for key dependencies to ensure compatibility and compliance.

#### PR Summary
Updates the package policy to disallow newer versions of MassTransit, AutoMapper, MediatR, and FluentAssertions, specifying maximum allowed versions and custom messages.
- packages-policy.json: Added disallowed rules for MassTransit, AutoMapper, and MediatR with version limits and messages.
- packages-policy.json: Updated FluentAssertions version constraint to v7.2.2 and added a custom message.
