### PR TITLE
Add GitHub NuGet source to workflow for private packages

### DIFF
--- a/.github/actions/validate-packages/action.yml
+++ b/.github/actions/validate-packages/action.yml
@@ -22,6 +22,10 @@ runs:
         with:
           dotnet-version: '8.x'
 
+      - name: Add nuget package source
+        shell: bash
+        run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"
+
       - name: Restore dependencies
         shell: pwsh
         env:


### PR DESCRIPTION
Add GitHub NuGet source to workflow for private packages

Added a workflow step to configure the GitHub NuGet package source using the GitHub token. This allows access to private packages from the specified feed during the .NET restore process.