### PR TITLE
Update action to use github-token input for NuGet auth

### DIFF
--- a/.github/actions/validate-packages/action.yml
+++ b/.github/actions/validate-packages/action.yml
@@ -6,6 +6,9 @@ inputs:
   environment:
     description: "Environment name for validation"
     required: true
+  github-token:
+    description: 'The GITHUB_TOKEN'
+    required: true
 
 runs:
   using: "composite"
@@ -24,7 +27,7 @@ runs:
 
       - name: Add nuget package source
         shell: bash
-        run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"
+        run: dotnet nuget add source --username USERNAME --password ${{ inputs.github-token }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"
 
       - name: Restore dependencies
         shell: pwsh


### PR DESCRIPTION
Update action to use github-token input for NuGet auth

Added a required github-token input to action.yml and updated the NuGet source step to use this input for authentication, enabling explicit token passing instead of relying on secrets context.