### PR TITLE
Update workflow to restore using detected .sln file

### DIFF
--- a/.github/actions/validate-packages/action.yml
+++ b/.github/actions/validate-packages/action.yml
@@ -33,7 +33,10 @@ runs:
         shell: pwsh
         env:
           DOTNET_ROLL_FORWARD: Major
-        run: dotnet restore
+        run: |
+          $slnFile = Get-ChildItem -Path . -Filter *.sln -Recurse | Select-Object -First 1
+          if (-not $slnFile) { throw "No .sln file found" }
+          dotnet restore $slnFile.FullName
 
       - name: Install license tool
         shell: pwsh


### PR DESCRIPTION
Update workflow to restore using detected .sln file

The restore dependencies step now searches for a .sln file and runs dotnet restore on it. If no solution file is found, the workflow fails with an error. This ensures dependencies are restored for the correct solution.